### PR TITLE
#24 Bucket should no longer use random provider

### DIFF
--- a/journal/week-1.md
+++ b/journal/week-1.md
@@ -46,4 +46,25 @@ This is the default file to load in terraform variables in blunk
 -TODO: documment this functionalit for terraform cloud 
 
 ### order of terraform variables
--TODO : document which terraform variables take presidence
+-TODO : document which terraform variables take presedence.
+
+## Dealing with configuration Drift
+
+## What happens if we loose our state file?
+
+If you lose your statefile, you most likley have to tear down all your cloud infrastructure manually.
+
+You can use terraform port but it won't for all cloud resources. You need check the terraform providers documentation for which resources support import.
+
+## Fixing Missing Resources with Terraform Import
+
+`terraform import aws_s3_bucket.bucket bucket-name`
+
+[AWS_S3_BUCKET](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#import)
+[Terraform Import](https://developer.hashicorp.com/terraform/language/import)
+
+### Fix Manual configuration
+
+If someone goes and delete or modifies cloud resources manually through Clickops.
+If we rerun Terraform plan back into the expected state fixing configuration drift
+

--- a/main.tf
+++ b/main.tf
@@ -1,16 +1,10 @@
 
 #https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string
-resource "random_string" "bucket_name" {
-  lower   = true
-  upper   = false
-  length  = 32
-  special = false
 
-}
 
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket
-resource "aws_s3_bucket" "example" {
-  bucket = random_string.bucket_name.result
+resource "aws_s3_bucket" "website_bucket" {
+  bucket = var.bucket_name
 
   tags = {
     User_uuid = var.user_uuid

--- a/output.tf
+++ b/output.tf
@@ -1,3 +1,3 @@
-output "random_bucket_name" {
-  value = random_string.bucket_name.result
+output "bucket_name" {
+  value = aws_s3_bucket.website_bucket.bucket
 }

--- a/provider.tf
+++ b/provider.tf
@@ -9,10 +9,6 @@ terraform {
   # }
 
   required_providers {
-    random = {
-      source  = "hashicorp/random"
-      version = "3.5.1"
-    }
     aws = {
       source  = "hashicorp/aws"
       version = "5.17.0"

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,1 +1,2 @@
 user_uuid="f0e61796-d3e3-4491-806d-03ac807bc685"
+bucket_name="kogstxgykts29drss9h756y1gfuk9ccr"

--- a/variable.tf
+++ b/variable.tf
@@ -10,3 +10,13 @@ variable "user_uuid" {
     error_message = "User UUID must be in the format of a UUID (e.g., 123e4567-e89b-12d3-a456-426614174000)"
   }
 }
+
+variable "bucket_name" {
+  description = "The AWS S3 bucket name"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9.-]{3,63}$", var.bucket_name))
+    error_message = "The bucket name must be between 3 and 63 characters and can only contain letters, numbers, hyphens, and periods."
+  }
+}


### PR DESCRIPTION
 - [x] use terraform import
 - [x] purposely cause configuration drift via clickops, and correct state